### PR TITLE
Update docker.md

### DIFF
--- a/installation/docker.md
+++ b/installation/docker.md
@@ -314,7 +314,7 @@ services:
       internal:
         ipv4_address: 172.25.1.2
   framework:
-    image: tarscloud/framework:v2.4.0
+    image: tarscloud/framework:latest
     container_name: tars-framework
     ports:
       - "3000:3000"


### PR DESCRIPTION
用docker-compose部署的环境，启动时报错如下，应该是镜像少了文件，改成latest版本就没有报错，并且与tarscloud/tars-node:latest的版本也对应上了

ERROR: for framework  Cannot start service framework: OCI runtime create failed: container_linux.go:346: starting container process caused "exec: \"/usr/local/tars/cpp/deploy/docker-init.sh\": stat /usr/local/tars/cpp/deploy/docker-init.sh: no such file or directory": unknown
ERROR: Encountered errors while bringing up the project.